### PR TITLE
chore: implement functions to track what images are available from a given source

### DIFF
--- a/source/argo_shared.go
+++ b/source/argo_shared.go
@@ -1,0 +1,158 @@
+package source
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	argov1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	argoclientset "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/cache"
+)
+
+type ArgoTemplateSourceOpts struct {
+	sourceName                 string
+	extractTemplatesFromObject func(obj interface{}) []argov1alpha1.Template
+	informer                   cache.SharedIndexInformer
+	resyncPeriod               time.Duration
+	client                     argoclientset.Interface
+}
+
+func NewArgoTemplateSource(opts *ArgoTemplateSourceOpts) ImageSource {
+	return &ArgoTemplateSource{
+		sourceName:                 opts.sourceName,
+		informer:                   opts.informer,
+		lock:                       sync.RWMutex{},
+		imageMap:                   make(map[string]bool),
+		images:                     make([]string, 0),
+		extractTemplatesFromObject: opts.extractTemplatesFromObject,
+		imageCh:                    make(chan string),
+		client:                     opts.client,
+		resyncPeriod:               opts.resyncPeriod,
+	}
+}
+
+type ArgoTemplateSource struct {
+	sourceName                 string
+	extractTemplatesFromObject func(obj interface{}) []argov1alpha1.Template
+	client                     argoclientset.Interface
+	imageCh                    chan string
+	resyncPeriod               time.Duration
+
+	informer cache.SharedIndexInformer
+	imageMap map[string]bool
+	images   []string
+	lock     sync.RWMutex
+}
+
+func (t *ArgoTemplateSource) ImageCh() <-chan string {
+	return t.imageCh
+}
+
+func (t *ArgoTemplateSource) Images() []string {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.images
+}
+
+func (ats *ArgoTemplateSource) Name() string {
+	return ats.sourceName
+}
+
+func (t *ArgoTemplateSource) updateImagesFromInformer() {
+	t.imageMap = t.getImagesFromInformer()
+
+	var images []string
+
+	for key := range t.imageMap {
+		images = append(images, key)
+	}
+
+	t.images = images
+}
+
+func (t *ArgoTemplateSource) getImagesFromInformer() map[string]bool {
+	imageMap := make(map[string]bool)
+
+	if t.informer != nil {
+
+		indexer := t.informer.GetIndexer()
+
+		for _, key := range indexer.ListKeys() {
+			value, exists, err := indexer.GetByKey(key)
+
+			if !exists {
+				logrus.Warnf("key %s did not exist in indexer", key)
+			} else if err != nil {
+				logrus.Errorf("failed to retrieve key %s from indexer: %v", key, err)
+			} else {
+				for image := range getImageSetFromTemplates(t.extractTemplatesFromObject(value)) {
+					imageMap[image] = true
+				}
+			}
+		}
+	}
+
+	t.informer.HasSynced()
+
+	return imageMap
+}
+
+func (t *ArgoTemplateSource) HasSynced() bool {
+	if t.informer != nil {
+		return t.informer.HasSynced()
+	}
+
+	return false
+}
+
+func (t *ArgoTemplateSource) Run(ctx context.Context) {
+	t.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			images := getImageSetFromTemplates(t.extractTemplatesFromObject(obj))
+
+			t.lock.Lock()
+			defer t.lock.Unlock()
+
+			newImages := setDifference(images, t.imageMap)
+
+			for _, image := range newImages {
+				t.imageMap[image] = true
+				t.images = append(t.images, image)
+				t.imageCh <- image
+			}
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			previousImages := getImageSetFromTemplates(t.extractTemplatesFromObject(oldObj))
+			currentImages := getImageSetFromTemplates(t.extractTemplatesFromObject(newObj))
+
+			deletedImages := setDifference(previousImages, currentImages)
+
+			t.lock.Lock()
+			defer t.lock.Unlock()
+
+			newImages := setDifference(currentImages, t.imageMap)
+
+			for _, image := range newImages {
+				t.imageMap[image] = true
+				t.images = append(t.images, image)
+				t.imageCh <- image
+			}
+
+			if len(deletedImages) > 0 {
+				t.updateImagesFromInformer()
+			}
+		},
+		DeleteFunc: func(_ interface{}) {
+			t.lock.Lock()
+			defer t.lock.Unlock()
+
+			t.updateImagesFromInformer()
+		},
+	})
+
+	t.informer.Run(ctx.Done())
+	close(t.imageCh)
+}

--- a/source/clusterworkflowtemplate.go
+++ b/source/clusterworkflowtemplate.go
@@ -1,51 +1,24 @@
 package source
 
 import (
-	"context"
 	"time"
 
 	argov1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	argoclientset "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
 	argoinformers "github.com/argoproj/argo-workflows/v3/pkg/client/informers/externalversions"
-	"k8s.io/client-go/tools/cache"
 )
 
-type ClusterWorkflowTemplateSource struct {
-	client       argoclientset.Interface
-	imageCh      chan string
-	resyncPeriod time.Duration
-}
-
-func (t *ClusterWorkflowTemplateSource) ImageCh() <-chan string {
-	return t.imageCh
-}
-
-func (ClusterWorkflowTemplateSource) Name() string {
-	return "ClusterWorkflowTemplate"
-}
-
-func (t *ClusterWorkflowTemplateSource) Run(ctx context.Context) {
-	fac := argoinformers.NewSharedInformerFactory(t.client, t.resyncPeriod)
-	inf := fac.Argoproj().V1alpha1().ClusterWorkflowTemplates().Informer()
-
-	handleWorkflowTemplateChange := func(obj interface{}) {
-		tmpl := obj.(*argov1alpha1.ClusterWorkflowTemplate)
-		emitImagesFromTemplatesToChan(tmpl.Spec.Templates, t.imageCh)
-	}
-
-	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    handleWorkflowTemplateChange,
-		UpdateFunc: skipOldObject(handleWorkflowTemplateChange),
-	})
-
-	inf.Run(ctx.Done())
-	close(t.imageCh)
-}
-
 func NewClusterWorkflowTemplateSource(client argoclientset.Interface, resyncPeriod time.Duration) ImageSource {
-	return &ClusterWorkflowTemplateSource{
-		imageCh:      make(chan string),
+	fac := argoinformers.NewSharedInformerFactory(client, resyncPeriod)
+
+	return NewArgoTemplateSource(&ArgoTemplateSourceOpts{
+		sourceName:   "ClusterWorkflowTemplate",
+		informer:     fac.Argoproj().V1alpha1().ClusterWorkflowTemplates().Informer(),
 		client:       client,
 		resyncPeriod: resyncPeriod,
-	}
+		extractTemplatesFromObject: func(obj interface{}) []argov1alpha1.Template {
+			tmpl := obj.(*argov1alpha1.ClusterWorkflowTemplate)
+			return tmpl.Spec.WorkflowSpec.Templates
+		},
+	})
 }

--- a/source/clusterworkflowtemplate_test.go
+++ b/source/clusterworkflowtemplate_test.go
@@ -1,0 +1,255 @@
+package source_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	argov1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	fake "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/fake"
+	"github.com/dcherman/image-cache-daemon/source"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_ClusterWorkflowTemplateSource_Containers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.ClusterWorkflowTemplate{
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Container: &v1.Container{
+							Image: "alpine",
+						},
+					},
+					{
+						Container: &v1.Container{
+							Image: "debian",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewClusterWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"alpine", "debian"})
+}
+
+func Test_ClusterWorkflowTemplateSource_Modify(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.ClusterWorkflowTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Container: &v1.Container{
+							Image: "alpine",
+						},
+					},
+					{
+						Container: &v1.Container{
+							Image: "debian",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewClusterWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	argoSource := src.(*source.ArgoTemplateSource)
+
+	for !argoSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	workflowTemplate.Spec.WorkflowSpec.Templates[0].Container.Image = "ubuntu"
+
+	_, err := fakeClient.ArgoprojV1alpha1().ClusterWorkflowTemplates().Update(ctx, &workflowTemplate, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian", "ubuntu"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"ubuntu", "debian"})
+}
+
+func Test_ClusterWorkflowTemplateSource_Delete(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.ClusterWorkflowTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Container: &v1.Container{
+							Image: "alpine",
+						},
+					},
+					{
+						Container: &v1.Container{
+							Image: "debian",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewClusterWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	argoSource := src.(*source.ArgoTemplateSource)
+
+	for !argoSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	err := fakeClient.ArgoprojV1alpha1().ClusterWorkflowTemplates().Delete(ctx, "test", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{})
+}
+
+func Test_ClusterWorkflowTemplateSource_Scripts(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.ClusterWorkflowTemplate{
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Script: &argov1alpha1.ScriptTemplate{
+							Container: v1.Container{
+								Image: "alpine",
+							},
+						},
+					},
+					{
+						Script: &argov1alpha1.ScriptTemplate{
+							Container: v1.Container{
+								Image: "debian",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewClusterWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"alpine", "debian"})
+}
+
+func Test_ClusterWorkflowTemplateSource_InitContainers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.ClusterWorkflowTemplate{
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						InitContainers: []argov1alpha1.UserContainer{
+							{
+								Container: v1.Container{
+									Image: "alpine",
+								},
+							},
+						},
+						Script: &argov1alpha1.ScriptTemplate{
+							Container: v1.Container{
+								Image: "debian",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewClusterWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"alpine", "debian"})
+}
+
+func Test_ClusterWorkflowTemplateSource_Name(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	src := source.NewClusterWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	assert.Equal(t, "ClusterWorkflowTemplate", src.Name())
+}

--- a/source/configmap.go
+++ b/source/configmap.go
@@ -2,6 +2,8 @@ package source
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -31,24 +33,12 @@ func WithConfigMapSelector(selector string) OptFn {
 	}
 }
 
-type ConfigMapSource struct {
-	configmapSelector string
-	logger            *logrus.Logger
-	client            kubernetes.Interface
-	imageCh           chan string
-	resyncPeriod      time.Duration
-}
+func getImagesFromConfigMap(obj interface{}) (map[string]bool, error) {
+	cm, ok := obj.(*corev1.ConfigMap)
 
-func (cms *ConfigMapSource) ImageCh() <-chan string {
-	return cms.imageCh
-}
-
-func (ConfigMapSource) Name() string {
-	return "ConfigMap"
-}
-
-func (cms ConfigMapSource) handleConfigMapChange(obj interface{}) {
-	cm := obj.(*corev1.ConfigMap)
+	if !ok {
+		return nil, fmt.Errorf("could not cast input to corev1.ConfigMap")
+	}
 
 	imagesKey := defaultImagesKey
 
@@ -56,47 +46,188 @@ func (cms ConfigMapSource) handleConfigMapChange(obj interface{}) {
 		imagesKey = value
 	}
 
+	imageMap := make(map[string]bool)
+
 	if imagesStr, ok := cm.Data[imagesKey]; ok {
 		var images []string
 
 		if err := yaml.Unmarshal([]byte(imagesStr), &images); err != nil {
-			cms.logger.Errorf("failed to unmarshal key %s in configmap %s/%s: %v", imagesKey, cm.Namespace, cm.Name, err)
-		} else {
-			for _, i := range images {
-				cms.imageCh <- i
+			return nil, fmt.Errorf("failed to unmarshal key %s in configmap %s/%s: %v", imagesKey, cm.Namespace, cm.Name, err)
+		}
+
+		for _, i := range images {
+			imageMap[i] = true
+		}
+	}
+
+	return imageMap, nil
+}
+
+type ConfigMapSource struct {
+	configmapSelector string
+	logger            *logrus.Logger
+	client            kubernetes.Interface
+	imageCh           chan string
+	imageMap          map[string]bool
+	informer          cache.SharedIndexInformer
+	images            []string
+	resyncPeriod      time.Duration
+	lock              sync.RWMutex
+}
+
+func (cms *ConfigMapSource) ImageCh() <-chan string {
+	return cms.imageCh
+}
+
+func (cms *ConfigMapSource) Images() []string {
+	cms.lock.RLock()
+	defer cms.lock.RUnlock()
+
+	return cms.images
+}
+
+func (*ConfigMapSource) Name() string {
+	return "ConfigMap"
+}
+
+func (cms *ConfigMapSource) updateImagesFromInformer() {
+	cms.imageMap = cms.getImagesFromInformer()
+
+	var images []string
+
+	for key := range cms.imageMap {
+		images = append(images, key)
+	}
+
+	cms.images = images
+}
+
+func (cms *ConfigMapSource) getImagesFromInformer() map[string]bool {
+	imageMap := make(map[string]bool)
+
+	if cms.informer != nil {
+		indexer := cms.informer.GetIndexer()
+
+		for _, key := range indexer.ListKeys() {
+			value, exists, err := indexer.GetByKey(key)
+
+			if !exists {
+				logrus.Warnf("key %s did not exist in indexer", key)
+			} else if err != nil {
+				logrus.Errorf("failed to retrieve key %s from indexer: %v", key, err)
+			} else {
+				images, err := getImagesFromConfigMap(value)
+
+				if err != nil {
+					cms.logger.Errorf("failed to get images from configmap: %v", err)
+					continue
+				}
+
+				for image := range images {
+					imageMap[image] = true
+				}
 			}
 		}
 	}
+
+	return imageMap
 }
 
 func (cms *ConfigMapSource) Run(ctx context.Context) {
-	fac := informers.NewSharedInformerFactoryWithOptions(cms.client, cms.resyncPeriod, informers.WithTweakListOptions(func(lo *v1.ListOptions) {
-		lo.LabelSelector = fields.ParseSelectorOrDie(cms.configmapSelector).String()
-	}))
+	cms.informer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			imageMap, err := getImagesFromConfigMap(obj)
 
-	inf := fac.Core().V1().ConfigMaps().Informer()
+			if err != nil {
+				cms.logger.Errorf("failed to get images from configmap: %v", err)
+				return
+			}
 
-	inf.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
-		AddFunc:    cms.handleConfigMapChange,
-		UpdateFunc: skipOldObject(cms.handleConfigMapChange),
+			cms.lock.Lock()
+			defer cms.lock.Unlock()
+
+			for key := range imageMap {
+				if _, exists := cms.imageMap[key]; !exists {
+					cms.imageMap[key] = true
+					cms.images = append(cms.images, key)
+					cms.imageCh <- key
+				}
+			}
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			currentImages, err := getImagesFromConfigMap(newObj)
+
+			if err != nil {
+				cms.logger.Errorf("failed to get images from configmap: %v", err)
+				return
+			}
+
+			previousImages, err := getImagesFromConfigMap(oldObj)
+
+			if err != nil {
+				cms.logger.Errorf("failed to get images from configmap: %v", err)
+				cms.logger.Warn("skipping deletion detection, could not parse prior images from configmap")
+				previousImages = currentImages
+			}
+
+			deletedImages := setDifference(previousImages, currentImages)
+
+			cms.lock.Lock()
+			defer cms.lock.Unlock()
+
+			newImages := setDifference(currentImages, cms.imageMap)
+
+			for _, image := range newImages {
+				cms.imageMap[image] = true
+				cms.images = append(cms.images, image)
+				cms.imageCh <- image
+			}
+
+			if len(deletedImages) > 0 {
+				cms.updateImagesFromInformer()
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			cms.lock.Lock()
+			defer cms.lock.Unlock()
+
+			cms.updateImagesFromInformer()
+		},
 	}, cms.resyncPeriod)
 
-	inf.Run(ctx.Done())
+	cms.informer.Run(ctx.Done())
 
 	close(cms.imageCh)
+}
+
+func (cms *ConfigMapSource) HasSynced() bool {
+	if cms.informer != nil {
+		return cms.informer.HasSynced()
+	}
+
+	return false
 }
 
 func NewConfigMapSource(client kubernetes.Interface, resyncPeriod time.Duration, opts ...OptFn) ImageSource {
 	cms := &ConfigMapSource{
 		imageCh:      make(chan string),
+		imageMap:     make(map[string]bool),
+		images:       make([]string, 0),
 		client:       client,
 		logger:       logrus.StandardLogger(),
+		lock:         sync.RWMutex{},
 		resyncPeriod: resyncPeriod,
 	}
 
 	for _, fn := range opts {
 		fn(cms)
 	}
+
+	fac := informers.NewSharedInformerFactoryWithOptions(client, resyncPeriod, informers.WithTweakListOptions(func(lo *v1.ListOptions) {
+		lo.LabelSelector = fields.ParseSelectorOrDie(cms.configmapSelector).String()
+	}))
+
+	cms.informer = fac.Core().V1().ConfigMaps().Informer()
 
 	return cms
 }

--- a/source/configmap_test.go
+++ b/source/configmap_test.go
@@ -27,7 +27,7 @@ func marshalOrPanic(obj interface{}) string {
 }
 
 func Test_ConfigMapSource_Defaults(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 
 	t.Cleanup(cancel)
 
@@ -69,8 +69,183 @@ func Test_ConfigMapSource_Defaults(t *testing.T) {
 	assert.Len(t, src.ImageCh(), 0)
 }
 
+func Test_ConfigMapSource_Modify(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	participatingConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "configmap-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "image-cache-daemon",
+			},
+		},
+		Data: map[string]string{
+			"images": marshalOrPanic([]string{"alpine", "debian"}),
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&participatingConfigMap)
+	src := source.NewConfigMapSource(fakeClient, time.Minute*15, source.WithConfigMapSelector("app.kubernetes.io/part-of=image-cache-daemon"))
+
+	go src.Run(ctx)
+
+	configmapSource := src.(*source.ConfigMapSource)
+
+	for !configmapSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	participatingConfigMap.Data["images"] = marshalOrPanic([]string{"ubuntu", "debian"})
+	_, err := fakeClient.CoreV1().ConfigMaps("default").Update(ctx, &participatingConfigMap, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian", "ubuntu"})
+	assert.ElementsMatch(t, []string{"debian", "ubuntu"}, src.Images())
+	assert.Len(t, src.ImageCh(), 0)
+}
+
+func Test_ConfigMapSource_Modify_Bad_Into_Good(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	participatingConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "configmap-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "image-cache-daemon",
+			},
+		},
+		Data: map[string]string{
+			"images": "][",
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&participatingConfigMap)
+	src := source.NewConfigMapSource(fakeClient, time.Minute*15, source.WithConfigMapSelector("app.kubernetes.io/part-of=image-cache-daemon"))
+
+	go src.Run(ctx)
+
+	configmapSource := src.(*source.ConfigMapSource)
+
+	for !configmapSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	participatingConfigMap.Data["images"] = marshalOrPanic([]string{"ubuntu", "debian"})
+	_, err := fakeClient.CoreV1().ConfigMaps("default").Update(ctx, &participatingConfigMap, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"ubuntu", "debian"})
+	assert.ElementsMatch(t, []string{"ubuntu", "debian"}, src.Images())
+	assert.Len(t, src.ImageCh(), 0)
+}
+
+func Test_ConfigMapSource_Modify_Good_Into_Bad(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	participatingConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "configmap-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "image-cache-daemon",
+			},
+		},
+		Data: map[string]string{
+			"images": marshalOrPanic([]string{"ubuntu", "debian"}),
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&participatingConfigMap)
+	src := source.NewConfigMapSource(fakeClient, time.Minute*15, source.WithConfigMapSelector("app.kubernetes.io/part-of=image-cache-daemon"))
+
+	go src.Run(ctx)
+
+	configmapSource := src.(*source.ConfigMapSource)
+
+	for !configmapSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	participatingConfigMap.Data["images"] = "]["
+	_, err := fakeClient.CoreV1().ConfigMaps("default").Update(ctx, &participatingConfigMap, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"ubuntu", "debian"})
+	assert.ElementsMatch(t, []string{"ubuntu", "debian"}, src.Images())
+	assert.Len(t, src.ImageCh(), 0)
+}
+
+func Test_ConfigMapSource_Delete(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	participatingConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "configmap-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "image-cache-daemon",
+			},
+		},
+		Data: map[string]string{
+			"images": marshalOrPanic([]string{"alpine", "debian"}),
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&participatingConfigMap)
+	src := source.NewConfigMapSource(fakeClient, time.Minute*15, source.WithConfigMapSelector("app.kubernetes.io/part-of=image-cache-daemon"))
+
+	go src.Run(ctx)
+
+	configmapSource := src.(*source.ConfigMapSource)
+
+	for !configmapSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	err := fakeClient.CoreV1().ConfigMaps("default").Delete(ctx, "configmap-1", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.ElementsMatch(t, []string{}, src.Images())
+	assert.Len(t, src.ImageCh(), 0)
+}
+
 func Test_ConfigMapSource_AlternateKey(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 
 	t.Cleanup(cancel)
 
@@ -107,7 +282,7 @@ func Test_ConfigMapSource_AlternateKey(t *testing.T) {
 }
 
 func Test_ConfigMapSource_Bad_Input(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	t.Cleanup(cancel)
 
 	logger, hook := test.NewNullLogger()

--- a/source/cronworkflowtemplate.go
+++ b/source/cronworkflowtemplate.go
@@ -1,51 +1,24 @@
 package source
 
 import (
-	"context"
 	"time"
 
 	argov1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	argoclientset "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
 	argoinformers "github.com/argoproj/argo-workflows/v3/pkg/client/informers/externalversions"
-	"k8s.io/client-go/tools/cache"
 )
 
-type CronWorkflowTemplateSource struct {
-	client       argoclientset.Interface
-	imageCh      chan string
-	resyncPeriod time.Duration
-}
-
-func (t *CronWorkflowTemplateSource) ImageCh() <-chan string {
-	return t.imageCh
-}
-
-func (CronWorkflowTemplateSource) Name() string {
-	return "CronWorkflowTemplateSource"
-}
-
-func (t *CronWorkflowTemplateSource) Run(ctx context.Context) {
-	fac := argoinformers.NewSharedInformerFactory(t.client, t.resyncPeriod)
-	inf := fac.Argoproj().V1alpha1().CronWorkflows().Informer()
-
-	handleWorkflowTemplateChange := func(obj interface{}) {
-		tmpl := obj.(*argov1alpha1.CronWorkflow)
-		emitImagesFromTemplatesToChan(tmpl.Spec.WorkflowSpec.Templates, t.imageCh)
-	}
-
-	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    handleWorkflowTemplateChange,
-		UpdateFunc: skipOldObject(handleWorkflowTemplateChange),
-	})
-
-	inf.Run(ctx.Done())
-	close(t.imageCh)
-}
-
 func NewCronWorkflowTemplateSource(client argoclientset.Interface, resyncPeriod time.Duration) ImageSource {
-	return &CronWorkflowTemplateSource{
-		imageCh:      make(chan string),
+	fac := argoinformers.NewSharedInformerFactory(client, resyncPeriod)
+
+	return NewArgoTemplateSource(&ArgoTemplateSourceOpts{
+		sourceName: "CronWorkflow",
+		informer:   fac.Argoproj().V1alpha1().CronWorkflows().Informer(),
+		extractTemplatesFromObject: func(obj interface{}) []argov1alpha1.Template {
+			tmpl := obj.(*argov1alpha1.CronWorkflow)
+			return tmpl.Spec.WorkflowSpec.Templates
+		},
 		client:       client,
 		resyncPeriod: resyncPeriod,
-	}
+	})
 }

--- a/source/cronworkflowtemplate_test.go
+++ b/source/cronworkflowtemplate_test.go
@@ -1,0 +1,256 @@
+package source_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	argov1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	fake "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/fake"
+	"github.com/dcherman/image-cache-daemon/source"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_CronWorkflowSource_Containers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	cronWorkflow := argov1alpha1.CronWorkflow{
+		Spec: argov1alpha1.CronWorkflowSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Container: &v1.Container{
+							Image: "alpine",
+						},
+					},
+					{
+						Container: &v1.Container{
+							Image: "debian",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&cronWorkflow)
+	src := source.NewCronWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"alpine", "debian"})
+}
+
+func Test_CronWorkflowSource_Modify(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	t.Cleanup(cancel)
+
+	cronWorkflow := argov1alpha1.CronWorkflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: argov1alpha1.CronWorkflowSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Container: &v1.Container{
+							Image: "alpine",
+						},
+					},
+					{
+						Container: &v1.Container{
+							Image: "debian",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&cronWorkflow)
+	src := source.NewCronWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	argoSource := src.(*source.ArgoTemplateSource)
+
+	for !argoSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	cronWorkflow.Spec.WorkflowSpec.Templates[0].Container.Image = "ubuntu"
+
+	_, err := fakeClient.ArgoprojV1alpha1().CronWorkflows("default").Update(ctx, &cronWorkflow, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian", "ubuntu"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"ubuntu", "debian"})
+}
+
+func Test_CronWorkflowSource_Delete(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	cronWorkflow := argov1alpha1.CronWorkflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: argov1alpha1.CronWorkflowSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Container: &v1.Container{
+							Image: "alpine",
+						},
+					},
+					{
+						Container: &v1.Container{
+							Image: "debian",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&cronWorkflow)
+	src := source.NewCronWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	argoSource := src.(*source.ArgoTemplateSource)
+
+	for !argoSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	err := fakeClient.ArgoprojV1alpha1().CronWorkflows("default").Delete(ctx, "test", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{})
+}
+
+func Test_CronWorkflowSource_Scripts(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	cronWorkflow := argov1alpha1.CronWorkflow{
+		Spec: argov1alpha1.CronWorkflowSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Script: &argov1alpha1.ScriptTemplate{
+							Container: v1.Container{
+								Image: "alpine",
+							},
+						},
+					},
+					{
+						Script: &argov1alpha1.ScriptTemplate{
+							Container: v1.Container{
+								Image: "debian",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&cronWorkflow)
+	src := source.NewCronWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"alpine", "debian"})
+}
+
+func Test_CronWorkflowSource_InitContainers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	cronWorkflow := argov1alpha1.CronWorkflow{
+		Spec: argov1alpha1.CronWorkflowSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						InitContainers: []argov1alpha1.UserContainer{
+							{
+								Container: v1.Container{
+									Image: "alpine",
+								},
+							},
+						},
+						Script: &argov1alpha1.ScriptTemplate{
+							Container: v1.Container{
+								Image: "debian",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&cronWorkflow)
+	src := source.NewCronWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"alpine", "debian"})
+}
+
+func Test_CronWorkflowSource_Name(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	src := source.NewCronWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	assert.Equal(t, "CronWorkflow", src.Name())
+}

--- a/source/source.go
+++ b/source/source.go
@@ -6,6 +6,7 @@ import (
 
 type ImageSource interface {
 	ImageCh() <-chan string
+	Images() []string
 	Name() string
 	Run(context.Context)
 }

--- a/source/static.go
+++ b/source/static.go
@@ -22,6 +22,10 @@ func (sis *StaticImageSource) ImageCh() <-chan string {
 	return sis.imageCh
 }
 
+func (sis *StaticImageSource) Images() []string {
+	return sis.images
+}
+
 func (sis *StaticImageSource) Run(ctx context.Context) {
 	for {
 		for _, i := range sis.images {

--- a/source/static_test.go
+++ b/source/static_test.go
@@ -33,6 +33,12 @@ func Test_StaticImageSource(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 10)
 	assert.ElementsMatch(t, emitted, []string{"foo", "bar", "baz"})
+	assert.ElementsMatch(t, src.Images(), []string{"foo", "bar", "baz"})
+}
+
+func Test_StaticImageSource_Name(t *testing.T) {
+	src := NewStaticImageSource([]string{}, 0)
+	assert.Equal(t, src.Name(), "static")
 }
 
 func Test_StaticImageSourceWithResync(t *testing.T) {

--- a/source/utils.go
+++ b/source/utils.go
@@ -4,26 +4,40 @@ import (
 	argov1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
-func emitImagesFromTemplatesToChan(templates []argov1alpha1.Template, ch chan<- string) {
-	images := make(map[string]bool)
+func getImageSetFromTemplates(templates []argov1alpha1.Template) map[string]bool {
+	imageMap := make(map[string]bool)
 
 	for _, t := range templates {
-		if t.Container != nil {
-			images[t.Container.Image] = true
-		}
-
 		for _, ic := range t.InitContainers {
-			images[ic.Container.Image] = true
+			imageMap[ic.Container.Image] = true
+		}
+
+		if t.Script != nil {
+			imageMap[t.Script.Image] = true
+		}
+
+		if t.Container != nil {
+			imageMap[t.Container.Image] = true
+		}
+
+		if t.ContainerSet != nil {
+			for _, c := range t.ContainerSet.Containers {
+				imageMap[c.Image] = true
+			}
 		}
 	}
 
-	for image := range images {
-		ch <- image
-	}
+	return imageMap
 }
 
-func skipOldObject(fn func(interface{})) func(interface{}, interface{}) {
-	return func(_ interface{}, obj interface{}) {
-		fn(obj)
+func setDifference(a map[string]bool, b map[string]bool) []string {
+	var results []string
+
+	for key := range a {
+		if _, exists := b[key]; !exists {
+			results = append(results, key)
+		}
 	}
+
+	return results
 }

--- a/source/workflowtemplate.go
+++ b/source/workflowtemplate.go
@@ -1,51 +1,24 @@
 package source
 
 import (
-	"context"
 	"time"
 
 	argov1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	argoclientset "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
 	argoinformers "github.com/argoproj/argo-workflows/v3/pkg/client/informers/externalversions"
-	"k8s.io/client-go/tools/cache"
 )
 
-type WorkflowTemplateSource struct {
-	client       argoclientset.Interface
-	imageCh      chan string
-	resyncPeriod time.Duration
-}
-
-func (t *WorkflowTemplateSource) ImageCh() <-chan string {
-	return t.imageCh
-}
-
-func (WorkflowTemplateSource) Name() string {
-	return "WorkflowTemplate"
-}
-
-func (t *WorkflowTemplateSource) Run(ctx context.Context) {
-	fac := argoinformers.NewSharedInformerFactory(t.client, t.resyncPeriod)
-	inf := fac.Argoproj().V1alpha1().WorkflowTemplates().Informer()
-
-	handleWorkflowTemplateChange := func(obj interface{}) {
-		tmpl := obj.(*argov1alpha1.WorkflowTemplate)
-		emitImagesFromTemplatesToChan(tmpl.Spec.Templates, t.imageCh)
-	}
-
-	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    handleWorkflowTemplateChange,
-		UpdateFunc: skipOldObject(handleWorkflowTemplateChange),
-	})
-
-	inf.Run(ctx.Done())
-	close(t.imageCh)
-}
-
 func NewWorkflowTemplateSource(client argoclientset.Interface, resyncPeriod time.Duration) ImageSource {
-	return &WorkflowTemplateSource{
-		imageCh:      make(chan string),
+	fac := argoinformers.NewSharedInformerFactory(client, resyncPeriod)
+
+	return NewArgoTemplateSource(&ArgoTemplateSourceOpts{
+		sourceName: "WorkflowTemplate",
+		informer:   fac.Argoproj().V1alpha1().WorkflowTemplates().Informer(),
+		extractTemplatesFromObject: func(obj interface{}) []argov1alpha1.Template {
+			tmpl := obj.(*argov1alpha1.WorkflowTemplate)
+			return tmpl.Spec.WorkflowSpec.Templates
+		},
 		client:       client,
 		resyncPeriod: resyncPeriod,
-	}
+	})
 }

--- a/source/workflowtemplate_test.go
+++ b/source/workflowtemplate_test.go
@@ -1,0 +1,263 @@
+package source_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	argov1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	fake "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/fake"
+	"github.com/dcherman/image-cache-daemon/source"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_WorkflowTemplateSource_Containers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.WorkflowTemplate{
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Container: &v1.Container{
+							Image: "alpine",
+						},
+					},
+					{
+						Container: &v1.Container{
+							Image: "debian",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"alpine", "debian"})
+}
+
+func Test_WorkflowTemplateSource_Modify(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.WorkflowTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Container: &v1.Container{
+							Image: "alpine",
+						},
+					},
+					{
+						Container: &v1.Container{
+							Image: "debian",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	argoSource := src.(*source.ArgoTemplateSource)
+
+	for !argoSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	workflowTemplate.Spec.WorkflowSpec.Templates[0].Container.Image = "ubuntu"
+
+	_, err := fakeClient.ArgoprojV1alpha1().WorkflowTemplates("default").Update(ctx, &workflowTemplate, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian", "ubuntu"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"ubuntu", "debian"})
+}
+
+func Test_WorkflowTemplateSource_Delete(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.WorkflowTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Container: &v1.Container{
+							Image: "alpine",
+						},
+					},
+					{
+						Container: &v1.Container{
+							Image: "debian",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	argoSource := src.(*source.ArgoTemplateSource)
+
+	for !argoSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	err := fakeClient.ArgoprojV1alpha1().WorkflowTemplates("default").Delete(ctx, "test", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{})
+}
+
+func Test_WorkflowTemplateSource_Scripts(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.WorkflowTemplate{
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						Script: &argov1alpha1.ScriptTemplate{
+							Container: v1.Container{
+								Image: "alpine",
+							},
+						},
+					},
+					{
+						Script: &argov1alpha1.ScriptTemplate{
+							Container: v1.Container{
+								Image: "debian",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	argoSource := src.(*source.ArgoTemplateSource)
+
+	for !argoSource.HasSynced() {
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"alpine", "debian"})
+}
+
+func Test_WorkflowTemplateSource_InitContainers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+
+	t.Cleanup(cancel)
+
+	workflowTemplate := argov1alpha1.WorkflowTemplate{
+		Spec: argov1alpha1.WorkflowTemplateSpec{
+			WorkflowSpec: argov1alpha1.WorkflowSpec{
+				Templates: []argov1alpha1.Template{
+					{
+						InitContainers: []argov1alpha1.UserContainer{
+							{
+								Container: v1.Container{
+									Image: "alpine",
+								},
+							},
+						},
+						Script: &argov1alpha1.ScriptTemplate{
+							Container: v1.Container{
+								Image: "debian",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&workflowTemplate)
+	src := source.NewWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	go src.Run(ctx)
+
+	var received []string
+
+	for image := range src.ImageCh() {
+		received = append(received, image)
+	}
+
+	assert.ElementsMatch(t, received, []string{"alpine", "debian"})
+	assert.Len(t, src.ImageCh(), 0)
+	assert.ElementsMatch(t, src.Images(), []string{"alpine", "debian"})
+}
+
+func Test_WorkflowTemplateSource_Name(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	src := source.NewWorkflowTemplateSource(fakeClient, time.Minute*15)
+
+	assert.Equal(t, "WorkflowTemplate", src.Name())
+}


### PR DESCRIPTION
As a pre-requisite to changing from a Daemonset based install to a Deployment one,
we need to be able to know what images should be applied to a node when a new one
is added to the cluster.  Previously, this would happen because each node would
get a cache pod which would determine this during initialization, however that
will no longer work with a single pod performing all cache operations.
